### PR TITLE
New Netbox Api requires the role field

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Script for automatically discovering network devices and adding them to NetBox. 
 ## Dependencies
 As root
 
-`pip3 install pynetbox toml lxml python-nmap`
+`pip3 install pynetbox toml lxml python-nmap pysnmp`
 
 `apt install nmap`
 ## Setup

--- a/netbox_templates.py
+++ b/netbox_templates.py
@@ -77,6 +77,7 @@ class NetBoxTemplate:
             site = self.default_site
         obj = {
             "name": name,
+            "role": {"name": device_role},
             "device_role": {"name": device_role},
             "device_type": {"manufacturer": {'name': manufacturer}, "model": model},
             "platform": {"name": platform} if platform else None,


### PR DESCRIPTION
The changes appear to work as expected when tested against the latest version of Netbox. This was achieved by incorporating the 'role' field into the Netbox template.